### PR TITLE
Moving conditional into parentheses.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var Logsene = function (options) {
   this.prettyPrint = options.prettyPrint || false
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false
   this.label = options.label || null
-  this.source = options.source || process.mainModule ? null : _dirname(process.mainModule.filename) || module.filename
+  this.source = options.source || (process.mainModule ? null : _dirname(process.mainModule.filename)) || module.filename
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
         return JSON.stringify(obj, null, 2)


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Operator_Precedence),
the ternary conditional operator comes just after the logical OR
operator. This would result in the source being set to _null_ when
the source from the options was defined.

@megastef can you review :eyeglasses: ?