### PR TITLE
Added custom rewriter for winston-logsene

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ logger.add (logsene, {token: process.env.LOGSENE_TOKEN, type: 'test_logs'})
 - __handleExceptions__ - boolean 'true' logs 'uncaught exceptions'
 - __exitOnError__ - if set to 'false' process will not exit after logging the 'uncaught exceptions'
 - __source__ - name of the logging source, by default name of the main node.js module
+- __rewriter__ - similar to rewriters in winston, rewriter allows modifying of __log meta__ but only for the logsene 
+  transport. This is a simple function which takes `level, msg, meta` as parameter and returns the new __meta__ array
 
 
 ### Examples
@@ -37,6 +39,16 @@ logger.info ("Info message no. %d logged to %s",1,'Logsene', {metadata: "test-lo
 logger.error ("Error message no. %d logged to %s",1,'Logsene', {metadata: "test-error", count:1, tags: ['test', 'error', 'winston']})
 logger.warn ("Warning message no. %d logged to %s",1,'Logsene', {metadata: "test-warning", count:1, tags: ['test', 'warning', 'winston']})
 logger.debug ("Debug message no. %d logged to %s",1,'Logsene', {metadata: "test-debug", count:1})
+
+// use custom rewriter
+var serverIp = "10.0.0.12";
+logger.add (logsene, {
+    token: process.env.LOGSENE_TOKEN,
+    rewriter: function (level, msg, meta) {
+      meta.ip = serverIp;
+      return meta;
+    }
+})
 
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var Logsene = function (options) {
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false
   this.label = options.label || null
   this.source = options.source || (process.mainModule ? null : _dirname(process.mainModule.filename)) || module.filename
+  this.rewriter = options.rewriter || null
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
       return JSON.stringify(obj, null, 2)
@@ -61,6 +62,9 @@ Logsene.prototype.log = function (level, msg, meta, callback) {
   }
   if (meta && (!meta['source'])) {
     meta.source = this.source
+  }
+  if (this.rewriter){
+    meta = this.rewriter(level, msg, meta)
   }
   var output = common.log({
     colorize: this.colorize,


### PR DESCRIPTION
In my logging environment, I need to add additional fields to every log entry in logsene, like `serverIp`, `clientIp`, `environment`, etc, but if I use the rewriters from winston, every transport gets these fields, but mostly these fields are not needed there. For example in the console I know exactly, which machine I'm working on.
Because of this I added a possibility to provide a rewriter function __only__ for the winston-logsene transport. Now you can add all the needed custom fields to the cloud, and another transports are not affected by this.