### PR TITLE
Fix error if app has no entry script

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ var Logsene = function (options) {
   this.prettyPrint = options.prettyPrint || false
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false
   this.label = options.label || null
-  this.source = options.source || (process.mainModule ? null : _dirname(process.mainModule.filename)) || module.filename
+  this.source = options.source || (process.mainModule ? _dirname(process.mainModule.filename) : null) || module.filename
 
   this.rewriter = options.rewriter || null
   if (this.json) {


### PR DESCRIPTION
If process.mainModule is undefined, an error was generated.