### PR TITLE
🐛🐛 Fix flushOnExit default.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var flat = require('flat')
 var Logsene = function (options) {
   Transport.call(this, options)
   options = options || {}
-  if (!options.flushOnExit) {
+  if (!options.hasOwnProperty('flushOnExit')) {
     options.flushOnExit = true
   }
   this.logCount = 0


### PR DESCRIPTION
Right now the `flushOnExit` option was always set to `true`, even if explicitly set to `false.